### PR TITLE
Athletics rss sync

### DIFF
--- a/app/Console/Commands/SyncAthleticsEvents.php
+++ b/app/Console/Commands/SyncAthleticsEvents.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Emutoday\Console\Commands;
+
+use Carbon\Carbon;
+use Emutoday\Event;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class SyncAthleticsEvents extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cea_events:sync_athletics';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import and sync EMU Athletics events from the Sidearm Sports RSS feed.';
+
+    /**
+     * Sidearm calendar RSS feed.
+     */
+    const FEED_URL = 'https://admin.emueagles.com/services/calendar_type.ashx?type=rss';
+
+    /**
+     * Mini calendar that imported athletics events are attached to.
+     */
+    const ATHLETICS_MINICAL_ID = 117;
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $xmlString = $this->fetchFeed();
+        if ($xmlString === false) {
+            Log::error('SyncAthleticsEvents: could not fetch RSS feed.');
+            $this->error('Could not fetch RSS feed.');
+            return 1;
+        }
+
+        $xml = simplexml_load_string($xmlString);
+        if ($xml === false) {
+            Log::error('SyncAthleticsEvents: could not parse RSS feed XML.');
+            $this->error('Could not parse RSS feed XML.');
+            return 1;
+        }
+
+        $created = 0;
+        $updated = 0;
+        $rssPermalinks = [];
+
+        foreach ($xml->channel->item as $item) {
+            $sdNs = $item->children('http://sidearmsports.com/schemas/cal_rss/1.0/');
+            $evNs = $item->children('http://purl.org/rss/1.0/modules/event/');
+
+            $permalink = trim((string) $item->guid);
+            if ($permalink === '') {
+                continue;
+            }
+            $rssPermalinks[] = $permalink;
+
+            $localStart = (string) $sdNs->localstartdate;
+            $localEnd   = (string) $sdNs->localenddate;
+
+            list($startDate, $startTime) = $this->splitLocalDateTime($localStart);
+            list($endDate, $endTime)     = $this->splitLocalDateTime($localEnd);
+
+            $rawDescription = (string) $item->description;
+            $links = $this->extractStreamingLinks($rawDescription);
+
+            $event = Event::firstOrNew(['sidearm_permalink' => $permalink]);
+            if (! $event->exists) {
+                $event->submission_date = Carbon::today();
+                $event->submitter = 'athletics_sync';
+                $created++;
+            } else {
+                $updated++;
+            }
+
+            $event->title       = $this->cleanTitle((string) $item->title);
+            $event->location    = (string) $evNs->location;
+            $event->description = $this->cleanDescription($rawDescription);
+
+            $event->start_date = $startDate;
+            $event->end_date   = $endDate ?: $startDate;
+
+            if ($startTime) {
+                $event->all_day    = 0;
+                $event->start_time = $startTime;
+                $event->end_time   = $endTime ?: $startTime;
+            } else {
+                // Time is TBA (feed sent a date-only localstartdate). Treat as all-day.
+                $event->all_day    = 1;
+                $event->start_time = '00:00:00';
+                $event->end_time   = '23:59:59';
+            }
+
+            $event->related_link_1     = (string) $item->link;
+            $event->related_link_1_txt = 'EMU Athletics';
+
+            $event->related_link_2     = $links['video'];
+            $event->related_link_2_txt = $links['video'] ? 'ESPN+ Streaming Video' : null;
+
+            $event->related_link_3     = $links['audio'];
+            $event->related_link_3_txt = $links['audio'] ? 'Streaming Audio' : null;
+
+            $event->contact_person = 'EMU Athletics';
+            $event->contact_email  = 'athletics@emich.edu';
+            $event->contact_phone  = '';
+
+            $event->cost        = '0';
+            $event->free        = 1;
+            $event->is_approved = 1;
+            $event->is_canceled = 0;
+
+            $event->save();
+            $event->minicalendars()->syncWithoutDetaching([self::ATHLETICS_MINICAL_ID]);
+        }
+
+        $canceled = $this->cancelStaleEvents($rssPermalinks);
+
+        $summary = "SyncAthleticsEvents complete. Created: {$created}, Updated: {$updated}, Canceled: {$canceled}.";
+        Log::info($summary);
+        $this->info($summary);
+
+        return 0;
+    }
+
+    /**
+     * Fetch the raw RSS feed body.
+     *
+     * @return string|false
+     */
+    protected function fetchFeed()
+    {
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => 30,
+                'user_agent' => 'EMUToday-AthleticsSync/1.0',
+            ],
+            'https' => [
+                'timeout' => 30,
+                'user_agent' => 'EMUToday-AthleticsSync/1.0',
+            ],
+        ]);
+
+        return @file_get_contents(self::FEED_URL, false, $context);
+    }
+
+    /**
+     * Split a Sidearm local datetime (e.g. "2026-04-28T08:00:00.0000000") into
+     * a [Y-m-d, H:i:s] pair.
+     *
+     * @param  string  $value
+     * @return array
+     */
+    protected function splitLocalDateTime($value)
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return [null, null];
+        }
+
+        // Some feed entries are date-only (time TBA), e.g. "2026-11-20".
+        if (strpos($value, 'T') === false) {
+            return [$value, null];
+        }
+
+        list($datePart, $timePart) = explode('T', $value, 2);
+        $timePart = substr($timePart, 0, 8); // strip fractional seconds / Z
+
+        return [$datePart, $timePart];
+    }
+
+    /**
+     * Strip the date/time/status prefix from a feed title.
+     * Titles look like "4/28 8:00 AM [N] EMU Women's Golf at MAC Championships".
+     * Take from the first "EMU" to the end; fall back to the full title.
+     *
+     * @param  string  $title
+     * @return string
+     */
+    protected function cleanTitle($title)
+    {
+        $title = trim($title);
+        $pos = stripos($title, 'EMU');
+
+        return $pos !== false ? trim(substr($title, $pos)) : $title;
+    }
+
+    /**
+     * Sidearm descriptions use literal "\n" (backslash-n text), not real newlines.
+     * Drop the TV/Streaming/Tickets marker lines and re-join with real newlines.
+     *
+     * @param  string  $raw
+     * @return string
+     */
+    protected function cleanDescription($raw)
+    {
+        $lines = explode('\n', $raw);
+        $kept = [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+            if ($this->isMarkerLine($line)) {
+                continue;
+            }
+            $kept[] = $line;
+        }
+
+        return implode("\n", $kept);
+    }
+
+    /**
+     * Pull the Streaming Video / Streaming Audio URLs out of the raw description.
+     *
+     * @param  string  $raw
+     * @return array  ['video' => ?string, 'audio' => ?string]
+     */
+    protected function extractStreamingLinks($raw)
+    {
+        $lines = explode('\n', $raw);
+        $video = null;
+        $audio = null;
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if (stripos($line, 'Streaming Video:') === 0) {
+                $url = trim(substr($line, strlen('Streaming Video:')));
+                $video = $url !== '' ? $url : null;
+            } elseif (stripos($line, 'Streaming Audio:') === 0) {
+                $url = trim(substr($line, strlen('Streaming Audio:')));
+                $audio = $url !== '' ? $url : null;
+            }
+        }
+
+        return ['video' => $video, 'audio' => $audio];
+    }
+
+    /**
+     * Marker lines that should not appear in the stored description.
+     *
+     * @param  string  $line
+     * @return bool
+     */
+    protected function isMarkerLine($line)
+    {
+        $markers = ['TV:', 'Streaming Video:', 'Streaming Audio:', 'Tickets:'];
+
+        foreach ($markers as $marker) {
+            if (stripos($line, $marker) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Cancel athletics events that have dropped out of the feed, but only within
+     * the feed window (it starts ~30 days before today). Older events that have
+     * simply aged off the feed must not be canceled.
+     *
+     * @param  array  $rssPermalinks
+     * @return int
+     */
+    protected function cancelStaleEvents(array $rssPermalinks)
+    {
+        $windowStart = Carbon::today()->subDays(30)->toDateString();
+
+        $query = Event::whereNotNull('sidearm_permalink')
+            ->where('start_date', '>=', $windowStart)
+            ->where('is_canceled', 0);
+
+        if (! empty($rssPermalinks)) {
+            $query->whereNotIn('sidearm_permalink', $rssPermalinks);
+        }
+
+        return $query->update(['is_canceled' => 1]);
+    }
+}

--- a/app/Console/Commands/SyncAthleticsEvents.php
+++ b/app/Console/Commands/SyncAthleticsEvents.php
@@ -114,7 +114,7 @@ class SyncAthleticsEvents extends Command
             $event->related_link_3_txt = $links['audio'] ? 'Streaming Audio' : null;
 
             $event->contact_person = 'EMU Athletics';
-            $event->contact_email  = 'athletics@emich.edu';
+            $event->contact_email  = 'athletic_marketing@emich.edu';
             $event->contact_phone  = '';
 
             $event->cost        = '0';
@@ -288,6 +288,6 @@ class SyncAthleticsEvents extends Command
             $query->whereNotIn('sidearm_permalink', $rssPermalinks);
         }
 
-        return $query->update(['is_canceled' => 1]);
+        return $query->update(['is_canceled' => 1, 'is_archived' => 1, 'is_hidden' => 1]);
     }
 }

--- a/app/Console/Commands/SyncAthleticsEvents.php
+++ b/app/Console/Commands/SyncAthleticsEvents.php
@@ -42,14 +42,14 @@ class SyncAthleticsEvents extends Command
     {
         $xmlString = $this->fetchFeed();
         if ($xmlString === false) {
-            Log::error('SyncAthleticsEvents: could not fetch RSS feed.');
+            Log::channel('athletics')->error('SyncAthleticsEvents: could not fetch RSS feed.');
             $this->error('Could not fetch RSS feed.');
             return 1;
         }
 
         $xml = simplexml_load_string($xmlString);
         if ($xml === false) {
-            Log::error('SyncAthleticsEvents: could not parse RSS feed XML.');
+            Log::channel('athletics')->error('SyncAthleticsEvents: could not parse RSS feed XML.');
             $this->error('Could not parse RSS feed XML.');
             return 1;
         }
@@ -129,7 +129,7 @@ class SyncAthleticsEvents extends Command
         $canceled = $this->cancelStaleEvents($rssPermalinks);
 
         $summary = "SyncAthleticsEvents complete. Created: {$created}, Updated: {$updated}, Canceled: {$canceled}.";
-        Log::info($summary);
+        Log::channel('athletics')->info($summary);
         $this->info($summary);
 
         return 0;

--- a/app/Console/Commands/SyncAthleticsEvents.php
+++ b/app/Console/Commands/SyncAthleticsEvents.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Emutoday\Event;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
+use Emutoday\Category;
 
 class SyncAthleticsEvents extends Command
 {
@@ -32,6 +33,30 @@ class SyncAthleticsEvents extends Command
      * Mini calendar that imported athletics events are attached to.
      */
     const ATHLETICS_MINICAL_ID = 117;
+
+    /**
+     * Sidearm calendar sport/type IDs mapped to display names and home venues.
+     * homeVenue is null if the sport is not played at a specific venue.
+     */
+    const SIDEARM_SPORTS = [
+        2  => ['sport' => 'Baseball', 'homeVenue' => 'Oestrike Stadium', 'sellsTickets' => false],
+        3  => ['sport' => 'Men\'s Basketball', 'homeVenue' => 'George Gervin GameAbove Center', 'sellsTickets' => true],
+        4  => ['sport' => 'Women\'s Basketball', 'homeVenue' => 'George Gervin GameAbove Center', 'sellsTickets' => true],
+        5  => ['sport' => 'Men\'s XC', 'homeVenue' => null, 'sellsTickets' => false],
+        6  => ['sport' => 'Women\'s XC', 'homeVenue' => null, 'sellsTickets' => false],
+        7  => ['sport' => 'Football', 'homeVenue' => 'Rynearson Stadium', 'sellsTickets' => true],
+        8  => ['sport' => 'Soccer', 'homeVenue' => 'Paul Scicluna Soccer Field', 'sellsTickets' => false],
+        10 => ['sport' => 'Men\'s Track & Field', 'homeVenue' => 'Olds-Marshall-Parks Track', 'sellsTickets' => false],
+        11 => ['sport' => 'Women\'s Track & Field', 'homeVenue' => 'Olds-Marshall-Parks Track', 'sellsTickets' => false],
+        12 => ['sport' => 'Volleyball', 'homeVenue' => 'George Gervin GameAbove Center', 'sellsTickets' => false],
+        13 => ['sport' => 'Men\'s Golf', 'homeVenue' => null, 'sellsTickets' => false],
+        16 => ['sport' => 'Women\'s Golf', 'homeVenue' => null, 'sellsTickets' => false],
+        17 => ['sport' => 'Women\'s Rowing', 'homeVenue' => 'Ford Lake', 'sellsTickets' => false],
+        18 => ['sport' => 'Gymnastics', 'homeVenue' => 'George Gervin GameAbove Center', 'sellsTickets' => false],
+        19 => ['sport' => 'Swimming & Diving', 'homeVenue' => 'Jones Natatorium', 'sellsTickets' => false],
+        20 => ['sport' => 'Tennis', 'homeVenue' => 'The Chippewa Club', 'sellsTickets' => false],
+        36 => ['sport' => 'Lacrosse', 'homeVenue' => 'Paul Scicluna Soccer Field', 'sellsTickets' => false],
+    ];
 
     /**
      * Execute the console command.
@@ -67,6 +92,9 @@ class SyncAthleticsEvents extends Command
                 continue;
             }
             $rssPermalinks[] = $permalink;
+
+            $sportId = $this->extractSportId($permalink);
+            $sport = self::SIDEARM_SPORTS[$sportId] ?? null;
 
             $localStart = (string) $sdNs->localstartdate;
             $localEnd   = (string) $sdNs->localenddate;
@@ -115,15 +143,64 @@ class SyncAthleticsEvents extends Command
 
             $event->contact_person = 'EMU Athletics';
             $event->contact_email  = 'athletic_marketing@emich.edu';
-            $event->contact_phone  = '';
+            $event->contact_phone  = '734.487.3369';
 
-            $event->cost        = '0';
-            $event->free        = 1;
+            // Home event is determined by <ev:location> containing 'Ypsilanti, Mich'
+            $isHomeEvent = (bool) preg_match('/\bYpsilanti, Mich\b/i', $event->location);
+            if($isHomeEvent) {
+                $event->on_campus = 1;
+            } else {
+                $event->on_campus = 0;
+            }
+
+            if($isHomeEvent && $sport['sellsTickets']) {
+                $event->cost        = 'Varies';
+                $event->free        = 0;
+                $event->tickets     = 'all';
+                $event->ticket_details_online = 'https://emueagles.com/tickets';
+                $event->ticket_details_phone = '734.487.3369';
+                $event->ticket_details_office = 'EMU Ticket Office: 799 N. Hewitt Rd. Ypsilanti, MI 48197';
+            } else if($sport['sellsTickets']) {
+                // Non-home event that sells tickets
+                $event->cost        = 'Road Event - Varies';
+                $event->free        = 0;
+                $event->tickets     = null;
+                $event->ticket_details_online = null;
+                $event->ticket_details_phone = null;
+                $event->ticket_details_office = null;
+            } else {
+                // Any event that does not sell tickets
+                $event->cost        = '0';
+                $event->free        = 1;
+                $event->tickets     = null;
+                $event->ticket_details_online = null;
+                $event->ticket_details_phone = null;
+                $event->ticket_details_office = null;
+            }
+
+            if($isHomeEvent && $sport['homeVenue']) {
+                if(
+                    ($sport['sport'] === 'Men\'s Track & Field' || $sport['sport'] === 'Women\'s Track & Field') &&
+                    $event->start_date->format('m') < 3 // Use March as the cutoff for outdoor track season
+                ) {
+                    $event->building = 'bowen-field-house';
+                } else {
+                    // Following the same pattern as when an event is created manually inside EMU Today.
+                    $event->building = preg_replace(["/[\s\\/]/", "/[^A-Za-z0-9-\\/]/"], ["-", ""], strtolower($sport['homeVenue']));
+                }
+            } else {
+                $event->building = null;
+            }
+
             $event->is_approved = 1;
             $event->is_canceled = 0;
 
             $event->save();
+            // Set mini-calendar to athletics
             $event->minicalendars()->syncWithoutDetaching([self::ATHLETICS_MINICAL_ID]);
+            // Set category to varsity athletics in cea_event_categories
+            $category = Category::where('category', 'Varsity Athletics')->first();
+            $event->eventcategories()->syncWithoutDetaching([$category->id]);
         }
 
         $canceled = $this->cancelStaleEvents($rssPermalinks);
@@ -289,5 +366,16 @@ class SyncAthleticsEvents extends Command
         }
 
         return $query->update(['is_canceled' => 1, 'is_archived' => 1, 'is_hidden' => 1]);
+    }
+
+    /**
+     * The sport_id is in the link tag of the event.
+     * @param mixed $link
+     */
+    protected function extractSportId($link) {
+        // e.g. <link>https://admin.emueagles.com/calendar.aspx?game_id=19565&amp;sport_id=10</link>
+        $matches = [];
+        preg_match('/sport_id=(\d+)/', $link, $matches);
+        return $matches[1] ?? null;
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -17,7 +17,8 @@ class Kernel extends ConsoleKernel
         Commands\SendTodayEmails::class,
         Commands\SendStoryIdeaEmail::class,
         Commands\SendIndividualStoryIdeaEmail::class,
-        Commands\ArchiveEvents::class
+        Commands\ArchiveEvents::class,
+        Commands\SyncAthleticsEvents::class
     ];
 
     /**
@@ -32,6 +33,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(Commands\SendStoryIdeaEmail::class)->cron('0 8 * * 3');
         $schedule->command(Commands\SendIndividualStoryIdeaEmail::class)->cron('0 8 * * 0-6');
         $schedule->command(Commands\ArchiveEvents::class)->cron('0 0 * * *');
+        $schedule->command(Commands\SyncAthleticsEvents::class)->cron('0 */6 * * *');
     }
 
     /**

--- a/app/Event.php
+++ b/app/Event.php
@@ -34,7 +34,8 @@ class Event extends Model{
 		'submission_date', 'approved_date', 'contact_fax', 'mini_calendar', 'lbc_reviewed', 'ensemble',
 		'mba', 'mini_calendar_alt', 'feature_image',
 		'hsc_rewards', 'hsc_reviewed',
-		'on_campus', 'mediafile_id', 'building_id', 'priority', 'is_hidden'];
+		'on_campus', 'mediafile_id', 'building_id', 'priority', 'is_hidden',
+		'sidearm_permalink'];
 
 
 	/**

--- a/config/logging.php
+++ b/config/logging.php
@@ -33,6 +33,13 @@ return [
     */
 
     'channels' => [
+        // Created for athletics RSS sync command 5/28/26
+        'athletics' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/athletics.log'),
+            'level' => 'info',
+        ],
+
         'stack' => [
             'driver' => 'stack',
             'channels' => ['single'],

--- a/database/migrations/2026_05_28_120000_add_sidearm_permalink_to_cea_events.php
+++ b/database/migrations/2026_05_28_120000_add_sidearm_permalink_to_cea_events.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSidearmPermalinkToCeaEvents extends Migration
+{
+    public function up()
+    {
+        Schema::table('cea_events', function (Blueprint $table) {
+            $table->string('sidearm_permalink', 500)->nullable()->after('external_record_id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('cea_events', function (Blueprint $table) {
+            $table->dropColumn('sidearm_permalink');
+        });
+    }
+}

--- a/docs/plans/athletics-rss-sync-plan.md
+++ b/docs/plans/athletics-rss-sync-plan.md
@@ -1,0 +1,99 @@
+# Athletics RSS Sync — Implementation Plan
+
+## Context
+EMU Today needs to periodically import athletic events from the EMU Athletics Sidearm Sports RSS feed (`https://admin.emueagles.com/services/calendar_type.ashx?type=rss`) and keep them in sync. Events can be created, updated, or removed on the Sidearm side and must be reflected in `cea_events`.
+
+The project already has a CampusLife external sync pattern using `external_record_id`. We'll follow that same approach but with a dedicated `sidearm_permalink` column (since that field is integer-based for CampusLife and the athletics key is a URL string).
+
+## Decisions
+- **Auto-approve**: `is_approved = 1` on create and update
+- **Removed events**: `is_canceled = 1` (but only for events within the RSS window — see below)
+- **Mini-calendar**: ID 117
+- **RSS window**: feed starts ~30 days before today; events older than that window must NOT be canceled just because they've aged off the feed
+
+## Files to Create/Modify
+
+### 1. Migration — add `sidearm_permalink` to `cea_events`
+New file: `database/migrations/[timestamp]_add_sidearm_permalink_to_cea_events.php`
+
+```php
+Schema::table('cea_events', function (Blueprint $table) {
+    $table->string('sidearm_permalink', 500)->nullable()->after('external_record_id');
+});
+```
+
+### 2. Event model — `app/Event.php`
+Add `sidearm_permalink` to `$fillable` array.
+
+### 3. Artisan command — `app/Console/Commands/SyncAthleticsEvents.php`
+Signature: `cea_events:sync_athletics`
+
+**handle() logic:**
+
+```
+1. Fetch RSS XML from Sidearm URL via file_get_contents / Http facade
+2. Parse XML, register sidearm 's' and 'ev' namespaces
+3. Build $rssPermalinks = [] of all guid values from RSS
+4. For each RSS item:
+   a. Extract fields:
+      - sidearm_permalink  ← <guid>
+      - title              ← <title> (full, including date prefix)
+      - location           ← <ev:location>
+      - description        ← <description> (plain text)
+      - start_date         ← date part of <s:localstartdate>
+      - start_time         ← time part of <s:localstartdate>
+      - end_date           ← date part of <s:localenddate>
+      - end_time           ← time part of <s:localenddate>
+      - related_link_1     ← <link> (back to emueagles.com)
+      - related_link_1_txt ← "EMU Athletics"
+   b. updateOrCreate(['sidearm_permalink' => $permalink], [all fields above plus:
+      - contact_person  = "EMU Athletics"
+      - contact_email   = "gsteiner2@emich.edu"
+      - contact_phone   = ""
+      - cost            = "0"
+      - free            = 1
+      - is_approved     = 1
+      - is_canceled     = 0  ← un-cancel if it reappears in feed
+      - submitter       = "athletics_sync"
+      - submission_date = today (only on create, via firstOrCreate semantics)
+   ])
+5. Cancel logic — only touch events within the RSS window:
+   $rssWindowStart = Carbon::today()->subDays(30)
+   Event::whereNotNull('sidearm_permalink')
+        ->where('start_date', '>=', $rssWindowStart)
+        ->whereNotIn('sidearm_permalink', $rssPermalinks)
+        ->update(['is_canceled' => 1])
+6. Log::info() with counts: created, updated, canceled
+```
+
+### 4. Console Kernel — `app/Console/Kernel.php`
+- Add `Commands\SyncAthleticsEvents::class` to `$commands` array
+- Add to schedule: `$schedule->command(Commands\SyncAthleticsEvents::class)->cron('0 */6 * * *');`
+  (runs every 6 hours)
+
+### 5. Mini-calendar attachment
+After `updateOrCreate`, attach mini-calendar 117:
+```php
+$event->minicalendars()->syncWithoutDetaching([117]);
+```
+Use `syncWithoutDetaching` so manually-added mini-cals on the event aren't wiped.
+
+## Field Mapping Reference (RSS → cea_events)
+| RSS field | DB column | Notes |
+|---|---|---|
+| `<guid>` | `sidearm_permalink` | Unique key, full URL |
+| `<title>` | `title` | Kept as-is (includes date prefix) |
+| `<ev:location>` | `location` | |
+| `<s:localstartdate>` | `start_date` + `start_time` | Local ET, split on T |
+| `<s:localenddate>` | `end_date` + `end_time` | Local ET, split on T |
+| `<description>` | `description` | Raw text |
+| `<link>` | `related_link_1` | Link back to athletics page |
+| — | `related_link_1_txt` | Hardcoded "EMU Athletics" |
+
+## Verification
+1. Run migration in container: `php artisan migrate`
+2. Run command manually: `php artisan cea_events:sync_athletics`
+3. Check logs: `storage/logs/laravel.log` for counts
+4. Confirm events appear in admin queue at `/admin/event/queue`
+5. Verify mini-calendar 117 is attached to imported events
+6. Test cancel logic: temporarily remove a `sidearm_permalink` from a future event in DB and re-run — confirm it gets `is_canceled=1`

--- a/docs/plans/athletics-rss-sync-plan.md
+++ b/docs/plans/athletics-rss-sync-plan.md
@@ -33,22 +33,32 @@ Signature: `cea_events:sync_athletics`
 ```
 1. Fetch RSS XML from Sidearm URL via file_get_contents / Http facade
 2. Parse XML, register sidearm 's' and 'ev' namespaces
+   NOTE: <description> uses LITERAL "\n" (backslash-n text), not real newlines.
+   Split/regex on the literal "\n" string when parsing markers and links.
 3. Build $rssPermalinks = [] of all guid values from RSS
 4. For each RSS item:
    a. Extract fields:
       - sidearm_permalink  ← <guid>
-      - title              ← <title> (full, including date prefix)
+      - title              ← <title>, prefix stripped: take from first "EMU" to end
+                             (drops the "4/28 8:00 AM [N] " date/time/status prefix).
+                             If no "EMU" present, fall back to the full title.
       - location           ← <ev:location>
-      - description        ← <description> (plain text)
+      - description        ← <description>, CLEANED: convert literal "\n" to real
+                             newlines and strip the "TV:", "Streaming Video:",
+                             "Streaming Audio:", "Tickets:" lines (those move to links)
       - start_date         ← date part of <s:localstartdate>
       - start_time         ← time part of <s:localstartdate>
       - end_date           ← date part of <s:localenddate>
       - end_time           ← time part of <s:localenddate>
       - related_link_1     ← <link> (back to emueagles.com)
       - related_link_1_txt ← "EMU Athletics"
+      - related_link_2     ← URL following "Streaming Video:" marker in <description> (often ESPN+)
+      - related_link_2_txt ← "ESPN+ Streaming Video" (only if related_link_2 found)
+      - related_link_3     ← URL following "Streaming Audio:" marker in <description>
+      - related_link_3_txt ← "Streaming Audio" (only if related_link_3 found)
    b. updateOrCreate(['sidearm_permalink' => $permalink], [all fields above plus:
       - contact_person  = "EMU Athletics"
-      - contact_email   = "gsteiner2@emich.edu"
+      - contact_email   = "athletics@emich.edu"
       - contact_phone   = ""
       - cost            = "0"
       - free            = 1
@@ -82,11 +92,15 @@ Use `syncWithoutDetaching` so manually-added mini-cals on the event aren't wiped
 | RSS field | DB column | Notes |
 |---|---|---|
 | `<guid>` | `sidearm_permalink` | Unique key, full URL |
-| `<title>` | `title` | Kept as-is (includes date prefix) |
+| `<title>` | `title` | Remove prefix (always take from first instance of "EMU" to the end of the title) |
 | `<ev:location>` | `location` | |
 | `<s:localstartdate>` | `start_date` + `start_time` | Local ET, split on T |
 | `<s:localenddate>` | `end_date` + `end_time` | Local ET, split on T |
-| `<description>` | `description` | Raw text |
+| `<description>` | `description` | Cleaned: literal `\n`→newlines, strip TV/Streaming/Tickets lines |
+| `<description>` | `related_link_2` | URL following `Streaming Video:` marker (NOT "ESPN+ Streaming Video:") |
+| - | `related_link_2_txt` | Hardcoded "ESPN+ Streaming Video" (only if link found) |
+| `<description>` | `related_link_3` | URL following `Streaming Audio:` marker |
+| - | `related_link_3_txt` | Hardcoded "Streaming Audio" (only if link found) |
 | `<link>` | `related_link_1` | Link back to athletics page |
 | — | `related_link_1_txt` | Hardcoded "EMU Athletics" |
 


### PR DESCRIPTION
Created a Laravel command that fires every 6 hours and pulls the RSS feed from emueagles.com. 

The feed contains all events starting from a month in the past and ends with the last scheduled event in the system. 

Events that are not present in EMU Today will be created. Events that exist will be updated with any changes. Events that are no longer present in the RSS feed (and are not outside of the date range of the feed) will be canceled, archived, and hidden.